### PR TITLE
Minor tweaks and fixes

### DIFF
--- a/ESH-INF/thing/switch.xml
+++ b/ESH-INF/thing/switch.xml
@@ -4,15 +4,16 @@
 	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
 	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
 
-	<thing-type id="lighting">
+	<thing-type id="switch">
 	
         <supported-bridge-type-refs>
             <bridge-type-ref id="bridge" />
         </supported-bridge-type-refs>
 
-		<label>RFLink Lighting device</label>
-		<description>A socket lighting device.</description>
+		<label>RFLink Switch or Contact device</label>
+		<description>A switch or contact device. (Contacts are read-only Switches).</description>
 
+        <!--X10 DS90 Door / Window contacts: 20;04;X10Secure;ID=12ab;SWITCH=00;CMD=OFF; -->
 		<channels>
 			<channel id="command" typeId="command" />
 		</channels>
@@ -20,7 +21,7 @@
 		<config-description>
 			<parameter name="deviceId" type="text" required="true">
 				<label>Device Id</label>
-				<description>Device Id. Device name + channel. Example Kaku-44</description>
+				<description>Device Id. Device name + channel. Example Kaku-44 or Device name + ID + channel; X10Secure-12ab-00</description>
 			</parameter>
 		</config-description>
 	</thing-type>

--- a/ESH-INF/thing/temperature.xml
+++ b/ESH-INF/thing/temperature.xml
@@ -12,7 +12,7 @@
 		<label>RFLink Temperature Sensor</label>
 		<description>A Temperature device.</description>
 
-        <!-- Sample: 2017-09-25 14:49:55 - 20;51;Oregon Temp;ID=0710;TEMP=00b5;BAT=LOW; ->
+		<!-- Sample: 2017-09-25 14:49:55 - 20;51;Oregon Temp;ID=0710;TEMP=00b5;BAT=LOW; -->
 		<channels>
 			<channel id="temperature" typeId="temperature" />
 			<channel id="lowBattery" typeId="system.low-battery" />

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RFLink binding for OpenHAB 2.0
+﻿# RFLink binding for OpenHAB 2.0
 
 [![Build Status](https://travis-ci.org/cyrilcc/org.openhab.binding.rflink.svg?branch=master)](https://travis-ci.org/cyrilcc/org.openhab.binding.rflink)
 
@@ -24,6 +24,7 @@ RFLink binding currently supports following types of devices:
 * Wind (_to be tested_)
 * Rain (_to be tested_)
 * Temperature
+* Switch / Contact
 
 As the project is at its very beginning, the binding does not support yet commands.
 
@@ -49,13 +50,14 @@ Bridge rflink:bridge:usb0 [ serialPort="COM19", baudRate=57600 ] {
 most of the time on a raspberry
 ```
 Bridge rflink:bridge:usb0 [ serialPort="/dev/ttyACM0", baudRate=57600 ] {
-    energy myEnergy [ deviceId="Oregon CM119-0004" ]
+    energy myEnergy [ deviceId="OregonCM119-0004" ]
 }
 ```
 or
 ```
 Bridge rflink:bridge:usb0 [ serialPort="/dev/ttyUSB0", baudRate=57600 ] {
-    temperature myTemperature [ deviceId="Oregon Temp-0710" ]
+    temperature myTemperature [ deviceId="OregonTemp-0710" ]
+    switch myContact [ deviceId="X10Secure-12ab-00" ]
 }
 ```
 
@@ -64,6 +66,7 @@ _.items file_
 Number myInstantPower "Instant Power [%d]"  <chart> (GroupA) {channel="rflink:energy:usb0:myEnergy:instantPower"}
 Number myTotalPower   "Total Power [%d]"    <chart> (GroupA) {channel="rflink:energy:usb0:myEnergy:totalUsage"}
 Number oregonTemp     "Oregon Temp [%.2f °C]"                {channel="rflink:temperature:usb0:myTemperature:temperature"}
+Switch myContact      "Contact [%s]"                         {channel="rflink:switch:usb0:myContact:command"}
 ```
 
 ## Supported Channels
@@ -106,6 +109,14 @@ Number oregonTemp     "Oregon Temp [%.2f °C]"                {channel="rflink:t
 | Channel ID  | Item Type    | Description  |
 |-------------|--------------|--------------|
 | temperature | Number       | Temperature  |
+
+
+### Switch
+
+
+| Channel ID  | Item Type    | Description  |
+|-------------|--------------|--------------|
+| switch      | Switch       | Command      |
 
 
 ## Dependencies
@@ -160,7 +171,7 @@ The full protocol reference is available in this [archive](https://drive.google.
 ### How to get sample messages of your Thing
 
 To get sample messages of your Thing, you can enable the DEBUG mode for this binding. 
-Add this line is your org.ops4j.pax.logging.cfg file
+Add this line to your org.ops4j.pax.logging.cfg file
  ```
  log4j.logger.org.openhab.binding.rflink = DEBUG
  ```

--- a/src/main/java/org/openhab/binding/rflink/RfLinkBindingConstants.java
+++ b/src/main/java/org/openhab/binding/rflink/RfLinkBindingConstants.java
@@ -73,7 +73,7 @@ public class RfLinkBindingConstants {
     public final static String CHANNEL_SET_POINT = "setpoint";
 
     // List of all Thing Type UIDs
-    public final static ThingTypeUID THING_TYPE_LIGHTNING = new ThingTypeUID(BINDING_ID, "lighting");
+    public final static ThingTypeUID THING_TYPE_SWITCH = new ThingTypeUID(BINDING_ID, "switch");
     public final static ThingTypeUID THING_TYPE_ENERGY = new ThingTypeUID(BINDING_ID, "energy");
     public final static ThingTypeUID THING_TYPE_WIND = new ThingTypeUID(BINDING_ID, "wind");
     public final static ThingTypeUID THING_TYPE_RAIN = new ThingTypeUID(BINDING_ID, "rain");
@@ -83,5 +83,5 @@ public class RfLinkBindingConstants {
      * Presents all supported Thing types by RFLink binding.
      */
     public final static Set<ThingTypeUID> SUPPORTED_DEVICE_THING_TYPES_UIDS = ImmutableSet.of(THING_TYPE_ENERGY,
-            THING_TYPE_WIND, THING_TYPE_LIGHTNING, THING_TYPE_RAIN, THING_TYPE_TEMPERATURE);
+            THING_TYPE_WIND, THING_TYPE_SWITCH, THING_TYPE_RAIN, THING_TYPE_TEMPERATURE);
 }

--- a/src/main/java/org/openhab/binding/rflink/messages/RfLinkBaseMessage.java
+++ b/src/main/java/org/openhab/binding/rflink/messages/RfLinkBaseMessage.java
@@ -68,7 +68,10 @@ public abstract class RfLinkBaseMessage implements RfLinkMessage {
             if (NODE_NUMBER_FROM_GATEWAY.equals(elements[0])) {
 
                 seqNbr = (byte) Integer.parseInt(elements[1], 16);
-                deviceName = elements[2];
+
+                // Fix for "UID segment 'Oregon Temp_0710' contains invalid characters. Each segment of the UID must
+                // match the pattern [A-Za-z0-9_-]*."
+                deviceName = elements[2].replaceAll("[^A-Za-z0-9_-]", "");
                 deviceId = elements[3].split(STR_VALUE_DELIMITER)[1];
 
                 // Raw values are stored, and will be decoded by sub implementations

--- a/src/main/java/org/openhab/binding/rflink/messages/RfLinkMessageFactory.java
+++ b/src/main/java/org/openhab/binding/rflink/messages/RfLinkMessageFactory.java
@@ -19,7 +19,7 @@ public class RfLinkMessageFactory {
         addMappingOfClass(RfLinkEnergyMessage.class);
         addMappingOfClass(RfLinkWindMessage.class);
         addMappingOfClass(RfLinkRainMessage.class);
-        addMappingOfClass(RfLinkLightingMessage.class);
+        addMappingOfClass(RfLinkSwitchMessage.class);
         addMappingOfClass(RfLinkTemperatureMessage.class);
     }
 

--- a/src/main/java/org/openhab/binding/rflink/messages/RfLinkSwitchMessage.java
+++ b/src/main/java/org/openhab/binding/rflink/messages/RfLinkSwitchMessage.java
@@ -23,7 +23,7 @@ import org.openhab.binding.rflink.exceptions.RfLinkException;
  *
  * @author Daan Sieben - Initial contribution
  */
-public class RfLinkLightingMessage extends RfLinkBaseMessage {
+public class RfLinkSwitchMessage extends RfLinkBaseMessage {
 
     private static final String KEY_SWITCH = "SWITCH";
     private static final String KEY_CMD = "CMD";
@@ -67,17 +67,17 @@ public class RfLinkLightingMessage extends RfLinkBaseMessage {
     public String switchCode = "";
     public Commands command = Commands.OFF;
 
-    public RfLinkLightingMessage() {
+    public RfLinkSwitchMessage() {
 
     }
 
-    public RfLinkLightingMessage(String data) {
+    public RfLinkSwitchMessage(String data) {
         encodeMessage(data);
     }
 
     @Override
     public ThingTypeUID getThingType() {
-        return RfLinkBindingConstants.THING_TYPE_LIGHTNING;
+        return RfLinkBindingConstants.THING_TYPE_SWITCH;
     }
 
     @Override
@@ -104,7 +104,7 @@ public class RfLinkLightingMessage extends RfLinkBaseMessage {
             try {
                 command = Commands.fromString(values.get(KEY_CMD));
                 if (command == null) {
-                    throw new RfLinkException("Can't convert " + values.get(KEY_CMD) + " to Lighting Command");
+                    throw new RfLinkException("Can't convert " + values.get(KEY_CMD) + " to Switch Command");
                 }
             } catch (Exception e) {
                 command = Commands.UNKNOWN;


### PR DESCRIPTION
Remove non-alphanumerical characters from device name to conform to OH validation of device names; "Oregon Temp" -> "OregonTemp"

Fix typo in temperature.xml

Renamed 'lighting' to 'switch' as door/window sensors are not lights,
they are not switches either, but contacts (Effectively read-only
switches). RfLink uses the same packet format for light switches and
contacts.